### PR TITLE
fix: link to exercises in table of contents

### DIFF
--- a/readMe.md
+++ b/readMe.md
@@ -32,7 +32,7 @@
   - [Checking Data types](#checking-data-types)
 - [Comments](#comments)
 - [Variables](#variables)
-- [💻 Day 1: Exercises](#%f0%9f%92%bb-day-1-exercises)
+- [💻 Day 1: Exercises](#-day-1-exercises)
 
 
 


### PR DESCRIPTION
There seems to be an issue with GitHub markdown parser which ignores the emoji when automatically creating links to headings containing emojis. This PR fixes the link to the Day 1 Exercises in the table of contents.