### PR TITLE
array using splits example fix

### DIFF
--- a/05_Day/05_day_arrays.md
+++ b/05_Day/05_day_arrays.md
@@ -137,9 +137,9 @@ let companiesString = 'Facebook, Google, Microsoft, Apple, IBM, Oracle, Amazon'
 const companies = companiesString.split(',')
 
 console.log(companies) // ["Facebook", " Google", " Microsoft", " Apple", " IBM", " Oracle", " Amazon"]
-let text =
+let txt =
   'I love teaching and empowering people. I teach HTML, CSS, JS, React, Python.'
-const words = text.split(' ')
+const words = txt.split(' ')
 
 console.log(words)
 // the text has special characters think how you can just get only the words


### PR DESCRIPTION
to avoid using already defined text property definition