### PR TITLE
Show backslash character

### DIFF
--- a/02_Day/02_day_data_types.md
+++ b/02_Day/02_day_data_types.md
@@ -311,7 +311,7 @@ Asabeneh Yetayeh. I am 250. I live in Finland
 
 #### Long Literal Strings
 
-A string could be a single character or paragraph or a page. If the string length is too big it does not fit in one line. We can use the backslash character (\) at the end of each line to indicate that the string will continue on the next line.
+A string could be a single character or paragraph or a page. If the string length is too big it does not fit in one line. We can use the backslash character (\\) at the end of each line to indicate that the string will continue on the next line.
 **Example:**
 
 ```js


### PR DESCRIPTION
As you can see in the picture below the backslash character isn't shown.

![Screen Shot 2020-01-07 at 2 46 32 PM](https://user-images.githubusercontent.com/29816580/71920209-a8627b00-315c-11ea-9531-84b61bb595c7.png)

In this case Github also need to escape the "\\" in order to show it. ;)