### PR TITLE
typo with ==

### DIFF
--- a/03_Day/03_booleans_operators_date.md
+++ b/03_Day/03_booleans_operators_date.md
@@ -207,7 +207,7 @@ console.log('python'.length > 'dragon'.length)   // false
 Try to understand the above comparisons with some logic. Remember without any logic might be difficult.
 JavaScript is some how a wired kind of programming language. JavaScript code run and give you a result but unless you are good at it may not be the desired result.
 
-As rule of thumb, if a value is not true with == it will not be equall with ===. Using === is safer than using ===. The following [link](https://dorey.github.io/JavaScript-Equality-Table/) has an exhaustive list of comparison of data types.
+As rule of thumb, if a value is not true with == it will not be equall with ===. Using === is safer than using ==. The following [link](https://dorey.github.io/JavaScript-Equality-Table/) has an exhaustive list of comparison of data types.
 
 ### Logical Operators
 


### PR DESCRIPTION
Using === is safer than using ==