### PR TITLE
one line printFullName arrow function fix

### DIFF
--- a/07_Day/07_day_functions.md
+++ b/07_Day/07_day_functions.md
@@ -319,9 +319,7 @@ console.log(printFullName('Asabeneh', 'Yetayeh'))
 The above function has only the return statement, therefore, we can explicitly return it as follows.
 
 ```js
-const printFullName = (firstName, lastName) => {
-  return `${firstName} ${lastName}`
-}
+const printFullName = (firstName, lastName) => `${firstName} ${lastName}`
 
 console.log(printFullName('Asabeneh', 'Yetayeh'))
 ```


### PR DESCRIPTION
I proposed this fix since I thought you wanted to illustrate one line shorthand format of the arrow function. Otherwise, the two illustrations are the same and look duplicated