### PR TITLE
Add an alternative `keyboard shortcut` to open the browser

### DIFF
--- a/readMe.md
+++ b/readMe.md
@@ -180,7 +180,7 @@ Mac
 Command+Option+J
 
 Windows/Linux:
-Ctl+Shift+J
+Ctl+Shift+J or F12
 ```
 
 ![Opening console](images/opening_chrome_console_shortcut.png)


### PR DESCRIPTION
By using `Linux`, we can open DevTools using the key `F12`.