### PR TITLE
Fix: missing space in Day 3 Booleans File line 75

### DIFF
--- a/03_Day_Booleans_operators_date/03_booleans_operators_date.md
+++ b/03_Day_Booleans_operators_date/03_booleans_operators_date.md
@@ -72,7 +72,7 @@ We agreed that boolean values are either true or false.
 
 ### Truthy values
 
-- All numbers(positive and negative) are truthy except zero
+- All numbers (positive and negative) are truthy except zero
 - All strings are truthy except an empty string ('')
 - The boolean true
 


### PR DESCRIPTION
Line 75: "All numbers(positive and negative) are truthy except zero" - had a missing space, added it.
                                      